### PR TITLE
repo-dispatch-init~replace inline dispatch with reusable workflow

### DIFF
--- a/.github/workflows/dispatch-portfolio-update.yml
+++ b/.github/workflows/dispatch-portfolio-update.yml
@@ -3,29 +3,10 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'README.md'
+    paths:
+      - 'package.json'
 
 jobs:
   dispatch:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: mergente
-          repositories: mergente-site
-
-      - name: Dispatch portfolio-update event
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh api repos/mergente/mergente-site/dispatches \
-            --method POST \
-            -f event_type="portfolio-update" \
-            -f "client_payload[source_repo]=${{ github.repository }}" \
-            -f "client_payload[head_sha]=${{ github.sha }}" \
-            -f "client_payload[compare_url]=${{ github.event.compare }}"
+    uses: mergente/mergente-site/.github/workflows/dispatch-portfolio-update.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Simplifies portfolio dispatch workflow by replacing inline job with a reusable workflow from `mergente/mergente-site`
- Narrows trigger from all pushes to main (except README) to only `package.json` changes
- Uses `secrets: inherit` to pass credentials to the reusable workflow

## Test plan
- [ ] Verify the reusable workflow at `mergente/mergente-site/.github/workflows/dispatch-portfolio-update.yml@main` exists and is callable
- [ ] Push a change to `package.json` on main and confirm the dispatch fires
- [ ] Push a non-`package.json` change and confirm the workflow does not run