### PR TITLE
ai-docs~add Claude Code rules and GitHub Copilot instructions

### DIFF
--- a/.claude/rules/ai-models.md
+++ b/.claude/rules/ai-models.md
@@ -1,0 +1,241 @@
+---
+paths:
+  - "src/models/**/*.ts"
+---
+
+
+## Key Pattern: One File Per Provider
+
+Each AI SDK gets its own file in `src/models/`. The file initializes the client once at module scope, exports named async functions, and does nothing else. No Express logic belongs inside model files.
+
+```
+src/models/
+  gemini.ts       → @google/generative-ai
+  openai.ts       → openai
+  huggingface.ts  → @huggingface/inference
+  replicate.ts    → replicate
+```
+
+**Key rules:**
+- When adding a new AI provider, create `src/models/<provider>.ts` — do not add provider logic to `index.ts`.
+- Each model file exports only named async functions (no default exports).
+- Client initialization (`new GoogleGenerativeAI(...)`, `new OpenAI({})`, etc.) happens at module scope, not inside functions.
+- Add a `README.md` entry to `src/models/README.md` documenting the model name, capability, and any known limitations.
+
+### Files to explore
+- @src/models/gemini.ts
+- @src/models/openai.ts
+- @src/models/huggingface.ts
+- @src/models/replicate.ts
+- @src/models/README.md
+
+---
+
+## Key Pattern: Gemini Text and Streaming
+
+Gemini is used exclusively for text generation and prompt rephrasing — not image generation. The module exposes both a streaming variant (returns the raw stream for SSE) and a non-streaming variant (returns the full response string). The model is initialized once with `gemini-1.5-flash`.
+
+```typescript
+const genAI = new GoogleGenerativeAI(GEMINI_TOKEN)
+const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' })
+
+// Streaming — return the stream, let the caller iterate it
+async function makeImagePrompt(userPrompt: string) {
+    const { stream } = await model.generateContentStream(prompt)
+    return stream;
+}
+
+// Non-streaming — await the full response
+async function generateText(prompt: string) {
+    const result = await model.generateContent(prompt)
+    return result.response.text()
+}
+```
+
+**Key rules:**
+- Use `generateContentStream` and return the stream object when the route needs to SSE-stream chunks to the browser.
+- Use `generateContent` and return `result.response.text()` for single-shot text tasks.
+- `makeImagePrompt` prepends the module-level `starterPrompt` — do not duplicate that instruction in the route handler.
+- Gemini cannot generate images; route image generation requests to OpenAI, HuggingFace, or Replicate.
+- Check `chunk.candidates` and `chunk.candidates[0].finishReason === 'STOP'` before treating a chunk as the final one.
+
+### Files to explore
+- @src/models/gemini.ts
+- @src/index.ts
+
+---
+
+## Key Pattern: OpenAI Chat and Image
+
+The OpenAI module provides two separate functions: `makePrompt` for chat completions (GPT-4o-mini) and `makeImage` for image generation (DALL-E 3). The client is initialized with `new OpenAI({})` — API key is picked up automatically from `OPENAI_API_KEY` in the environment.
+
+```typescript
+const openai = new OpenAI({})
+
+// Chat — returns a streaming chat completion
+async function makePrompt(userInput: string) {
+    const chatStream = await openai.chat.completions.create({
+        model: 'gpt-4o-mini',
+        messages: [
+            { role: 'system', content: SYSTEM_PROMPT },
+            { role: 'user', content: userInput }
+        ],
+        stream: true,
+        stream_options: { "include_usage": true },
+    })
+    return chatStream;
+}
+
+// Image — returns the URL string from DALL-E
+async function makeImage(prompt: string) {
+    const response = await openai.images.generate({
+        model: 'dall-e-3',
+        n: 1,
+        prompt,
+    })
+    return response.data[0].url
+}
+```
+
+**Key rules:**
+- `new OpenAI({})` with an empty options object — the SDK reads `OPENAI_API_KEY` from the environment automatically.
+- Always include both `stream: true` and `stream_options: { "include_usage": true }` for streaming chat completions.
+- `makeImage` returns `response.data[0].url` — a string. The route renders this directly as `imgUrl`.
+- The system prompt for `makePrompt` instructs the model to use the input AS-IS to prevent DALL-E's built-in prompt revision from double-processing it.
+- Export `openai` as a named export so it can be reused by future functions in the same file.
+
+### Files to explore
+- @src/models/openai.ts
+
+---
+
+## Key Pattern: Hugging Face Image — Blob to Disk
+
+Hugging Face returns a `Blob` that must be manually converted to a `Buffer` and written to `src/public/assets/images/`. The file is saved with a timestamp suffix to avoid collisions. The function returns an object `{ imgUrl, altText }` — not the raw blob.
+
+```typescript
+async function hfImage(prompt: string) {
+    const imgReq = await hf.textToImage({
+        model: model_stable,
+        inputs: prompt,
+    })
+
+    const blob = imgReq as Blob;
+    const timestamp = new Date().toISOString()
+        .replace(/[:.]/g, '-').replace('T', '_').split('.')[0];
+    await storeImage(blob, `hf-image-stable_${timestamp}.jpg`)
+
+    return {
+        imgUrl: `/assets/images/hf-image-stable_${timestamp}.jpg`,
+        altText: prompt
+    }
+}
+
+async function blobToBuffer(blob: Blob): Promise<Buffer> {
+    const arrayBuffer = await blob.arrayBuffer()
+    return Buffer.from(arrayBuffer);
+}
+
+async function storeImage(blob: Blob, filename: string) {
+    const imageRoot = path.join(__dirname, '..', 'public', 'assets', 'images')
+    const buffer = await blobToBuffer(blob)
+    fs.createWriteStream(path.join(imageRoot, filename)).write(buffer)
+}
+```
+
+**Key rules:**
+- Cast the `textToImage` response to `Blob` explicitly — the SDK types it loosely.
+- Use `blobToBuffer` (the module-internal helper) for the Blob → Buffer conversion; do not inline the `arrayBuffer()` call.
+- Timestamp format: `new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').split('.')[0]` — keep consistent for predictable filenames.
+- The returned `imgUrl` path must be relative to `public/` (i.e., starts with `/assets/`) so it resolves as a static asset.
+- `storeImage` resolves the image root with `path.join(__dirname, '..', 'public', 'assets', 'images')` — maintain this relative path.
+
+### Files to explore
+- @src/models/huggingface.ts
+
+---
+
+## Key Pattern: Replicate Run API
+
+Replicate runs models by their version-pinned identifier string. Model IDs include the full SHA of the version. Parameters are passed inside an `input` object. The function returns whatever the model returns (array of URLs for images).
+
+```typescript
+const IMG_MODEL = 'adirik/flux-cinestill:216a43b9975de...'
+
+const replicateImage = async (prompt: string) => {
+    return await replicate.run(
+        IMG_MODEL,
+        {
+            input: {
+                model: "dev",
+                prompt,
+                lora_scale: 0.6,
+                num_outputs: 1,
+                aspect_ratio: "1:1",
+                output_format: "webp",
+                // ...
+            }
+        }
+    )
+}
+```
+
+**Key rules:**
+- Pin model identifiers to a specific SHA version string — never use a floating `latest` tag.
+- Store model identifiers as module-level `const` strings in SCREAMING_SNAKE_CASE (e.g., `IMG_MODEL`, `VIDEO_MODEL`).
+- Use arrow function syntax for Replicate wrappers (consistent with existing `replicateImage` and `replicateVideo`).
+- The route accesses `image[0]` (first element of the returned array) for the image URL — account for this when adding new Replicate model wrappers.
+- `auth` is passed via `process.env.REPLICATE_API_TOKEN` directly in the constructor — the SDK accepts `string | undefined`.
+
+### Files to explore
+- @src/models/replicate.ts
+- @src/index.ts
+
+---
+
+## Key Pattern: Model Constants at Module Scope
+
+Model name strings and configuration constants live at the top of each file, outside any function. This makes them easy to update and clearly documents which model version is in use.
+
+```typescript
+// gemini.ts
+const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' })
+
+// huggingface.ts
+const model_stable = 'stabilityai/stable-diffusion-3-medium-diffusers'
+
+// replicate.ts
+const IMG_MODEL = 'adirik/flux-cinestill:216a43b9975de9768114644bbf8cd0cba54a923c6d0f65adceaccfc9383a938f'
+const VIDEO_MODEL = 'cjwbw/videocrafter:02edcff3e9d2d11dcc27e530773d988df25462b1ee93ed0257b6f246de4797c8'
+```
+
+**Key rules:**
+- Model name strings are always module-level constants — never hardcoded inside function bodies.
+- Naming convention: `model_<variant>` (snake_case) for HuggingFace, `SCREAMING_SNAKE_CASE` for Replicate version-pinned strings.
+
+---
+
+## Key Pattern: System Prompts as Module Constants
+
+Multi-line system prompt strings are defined as module-level `const` using template literals. They are referenced inside the function that uses them, not inlined into the API call.
+
+```typescript
+const starterPrompt = `
+    You are an expert in prompt crafting.
+    Use the text input to craft a detailed prompt for image generation.
+    Keep the prompt length under 900 characters: `
+
+async function makeImagePrompt(userPrompt: string) {
+    const prompt = `
+        ${starterPrompt}
+        ${userPrompt}
+    `
+    // use prompt
+}
+```
+
+**Key rules:**
+- System prompts are `const` at module scope, not embedded inside function calls.
+- Compose the final prompt inside the function by interpolating `starterPrompt` + `userPrompt` — keeps the base instructions separate from user input.
+- OpenAI system prompts go in the `messages[0].content` field with `role: 'system'`.
+- Gemini system prompts are prepended to the user prompt as a single string (the SDK does not have a separate system-role concept in this version).

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,0 +1,241 @@
+---
+paths:
+  - "src/views/**/*.twig"
+  - "src/public/**/*.css"
+  - "src/public/**/*.js"
+---
+
+## Key Pattern: Twig Template Structure
+
+`base.twig` is the only full-page layout. It includes all `<head>` dependencies, the page shell, and the main form. Partials (in `src/views/partials/`) render HTML fragments only — no `<html>`, `<head>`, or `<body>` tags.
+
+```twig
+{# base.twig — full page layout #}
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <link rel="stylesheet" href="pico/pico.classless.min.css">
+        <link rel="stylesheet" href="css/main.css">
+        <script src="htmx/htmx.min.js"></script>
+        <title>{{ title }}</title>
+    </head>
+    <body>
+        {# page content #}
+        <script src="js/events.js"></script>
+    </body>
+</html>
+
+{# partials/generated-image.twig — fragment only #}
+<figure class="prompt__figure">
+    <img src="{{ imgUrl }}" alt="{{ altText }}" />
+</figure>
+```
+
+**Key rules:**
+- Asset paths use the mount aliases set in `index.ts`: `pico/`, `htmx/`, `css/`, `js/`, `svg/`.
+- The `<script src="js/events.js">` tag goes at the bottom of `<body>`, after all markup.
+- Partials only output the HTML fragment that will be swapped — no surrounding page structure.
+- Twig variables passed from `res.render` are referenced with `{{ variableName }}` syntax. Comments use `{# ... #}`.
+- `strict_variables: false` is set on the Twig engine — missing variables silently render as empty, not errors.
+
+### Files to explore
+- @src/views/base.twig
+- @src/views/partials/generated-image.twig
+- @src/index.ts
+
+---
+
+## Key Pattern: Twig Partials as HTMx Swap Targets
+
+The `res.render` call in Express renders a Twig partial whose output replaces the `hx-target` element in the browser. The partial receives a consistent set of props: `imgUrl`, `altText`, `generatedPrompt`.
+
+```typescript
+// Express route — render partial
+res.render(path.join('partials', 'generated-image'), {
+    generatedPrompt: req.body.promptRephrase,
+    imgUrl: image,
+    altText: req.body.promptRephrase,
+})
+```
+
+```twig
+{# partials/generated-image.twig #}
+<figure class="prompt__figure">
+    <img id="img-response" src="{{ imgUrl }}" alt="{{ altText }}" class="gen-ai-image htmx-indicator" />
+    <img src="/svg/loaders/puff.svg" alt="loading" class="prompt__response-loader htmx-indicator" />
+</figure>
+```
+
+**Key rules:**
+- Use `path.join('partials', 'generated-image')` (no `.twig` extension) — the Twig engine appends it.
+- The partial's root element must be a single container (`<figure>`) that replaces the entire `hx-target` inner HTML.
+- Always pass all three props — `generatedPrompt`, `imgUrl`, `altText` — from the route, even if the partial does not use all of them yet (forward compatibility).
+
+### Files to explore
+- @src/views/partials/generated-image.twig
+- @src/index.ts
+
+---
+
+## Key Pattern: HTMx Attributes
+
+HTMx is used for the image generation POST request. The form is submitted with `hx-post`, includes all form fields via `hx-include`, targets the response container with `hx-target`, and shows a loading indicator via `hx-indicator`.
+
+```html
+<button
+    hx-post="/make-image"
+    hx-include="#prompt-form"
+    hx-target=".prompt__response-image"
+    hx-swap="innerHTML"
+    hx-indicator=".prompt__response"
+>Generate Image</button>
+```
+
+**Key rules:**
+- `hx-include="#prompt-form"` sends all named inputs inside the form — this is how `modelApi` (radio) and `promptRephrase` (textarea) reach the server.
+- `hx-swap="innerHTML"` replaces the content inside the target, not the target itself — the wrapper `.prompt__response-image` persists.
+- `hx-indicator` points to the element that receives the `htmx-request` class during the request — used to drive CSS loading states.
+- SSE streaming (the `/make-prompt` route) is handled by vanilla JS `EventSource`, not HTMx SSE extension — the comment in `base.twig` explains why.
+
+### Files to explore
+- @src/views/base.twig
+
+---
+
+## Key Pattern: SSE Client with EventSource
+
+The client-side SSE handler lives in `src/public/js/events.js`. It intercepts the form's `submit` event, builds a query string from `FormData`, opens an `EventSource`, and streams JSON chunks into the `#prompt-result` textarea. An empty object payload signals completion and re-enables the submit button.
+
+```javascript
+form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    promptResult.innerHTML = '';
+
+    const formData = new FormData(form);
+    const urlParams = new URLSearchParams(formData);
+    const eventSource = new EventSource(`/make-prompt?${urlParams.toString()}`);
+
+    eventSource.onmessage = (event) => {
+        const data = JSON.parse(event.data);
+        if (data.promptResponse) {
+            form.querySelector('button').disabled = true;
+            promptResult.innerHTML += data.promptResponse;
+        } else {
+            form.querySelector('button').disabled = false;
+        }
+    };
+});
+```
+
+**Key rules:**
+- Always call `e.preventDefault()` on form submit before opening the `EventSource`.
+- Clear `promptResult.innerHTML = ''` at the start of each submission before streaming new content.
+- Parse each event's `data` as JSON — the server sends `JSON.stringify({ promptResponse: '...' })`.
+- An event with no `promptResponse` key (empty object `{}`) means the stream is complete — re-enable the button and the `EventSource` can be closed.
+- Append chunks with `+=` not `=` — each chunk is an incremental piece of the full response.
+
+### Files to explore
+- @src/public/js/events.js
+- @src/index.ts
+
+---
+
+## Key Pattern: CSS Naming and Nesting
+
+CSS uses a BEM-inspired flat naming convention: `.block`, `.block__element`. Nested rules use native CSS nesting (no preprocessor). Component blocks are scoped to their parent class.
+
+```css
+.prompt {
+    max-width: var(--img-dim);
+
+    .prompt__submit-button {
+        display: flex;
+        width: var(--img-dim);
+    }
+
+    .prompt__rephrase {
+        height: 368px;
+    }
+}
+
+.prompt__response {
+    .prompt__figure {
+        width: var(--img-dim);
+    }
+}
+```
+
+**Key rules:**
+- Class names follow `.<block>__<element>` for components (`prompt__submit-button`, `prompt__response-image`).
+- Use native CSS nesting (`&` is not required for descendant selectors inside a rule block) — no Sass or PostCSS.
+- Keep component styles together under their block selector, not scattered across the file.
+- `media-queries.css` is a separate file — add responsive overrides there, not inline in `main.css`.
+
+### Files to explore
+- @src/public/css/main.css
+- @src/public/css/media-queries.css
+
+---
+
+## Key Pattern: CSS Custom Properties for Dimensions
+
+Shared dimensional values are defined as CSS custom properties on `:root`. The canonical image size token is `--img-dim: 512px`.
+
+```css
+:root {
+    --img-dim: 512px;
+    --screen-tablet: 768px;
+}
+
+.prompt {
+    max-width: var(--img-dim);
+}
+```
+
+**Key rules:**
+- Never hardcode `512px` — use `var(--img-dim)`.
+- Add new shared values (colors, spacings, breakpoints) to `:root` in `main.css`.
+- `--screen-tablet` is the tablet breakpoint; `media-queries.css` uses `1024px` for the desktop layout shift — add new breakpoints as named custom properties.
+- PicoCSS classless styles provide base typography and form styling — avoid overriding PicoCSS variables unless necessary.
+
+### Files to explore
+- @src/public/css/main.css
+- @src/public/css/media-queries.css
+
+---
+
+## Key Pattern: HTMX Indicator Pattern
+
+HTMx loading states are driven by the `htmx-indicator` class and the `htmx-request` class that HTMx adds to the `hx-indicator` target during a request. Loading spinners use `opacity: 0` by default and `opacity: 1` during request. The generated image uses the same pattern in reverse.
+
+```css
+/* Default — show placeholder, hide loader */
+.prompt__response-image .prompt__figure {
+    .prompt__response-placeholder.htmx-indicator,
+    .gen-ai-image.htmx-indicator {
+        opacity: 1;
+    }
+}
+
+/* During request — hide both, show loader */
+.prompt__response.htmx-request {
+    .prompt__response-image .prompt__figure {
+        .htmx-indicator.prompt__response-placeholder,
+        .htmx-indicator.gen-ai-image {
+            opacity: 0;
+            display: none;
+        }
+    }
+}
+```
+
+**Key rules:**
+- Use `htmx-indicator` class on elements that should respond to request state — HTMx manages their default `opacity: 0` automatically.
+- Override `opacity: 1` explicitly when an indicator element should be *visible* in the default (non-request) state.
+- The loading spinner (puff.svg) and the generated image both carry `htmx-indicator` — CSS toggles between them based on request state.
+- Place spinner SVG at `/svg/loaders/puff.svg` — this path is resolved as a static asset.
+
+### Files to explore
+- @src/public/css/main.css
+- @src/views/base.twig
+- @src/views/partials/generated-image.twig

--- a/.claude/rules/typescript-express.md
+++ b/.claude/rules/typescript-express.md
@@ -1,0 +1,214 @@
+---
+paths:
+  - "src/**/*.ts"
+---
+
+
+## Key Pattern: Strict TypeScript Config
+
+The project runs `strict: true`, `noImplicitAny: true`, and `strictNullChecks: true`. These cannot be loosened. Target is `es2016`, module system is `commonjs`. Output goes to `dist/`, source root is `src/`.
+
+**Key rules:**
+- Never disable or comment out `strict`, `noImplicitAny`, or `strictNullChecks` in `tsconfig.json`.
+- When the TypeScript compiler cannot infer a type, add an explicit annotation — do not fall back to `any` unless you write an explanatory comment (see the `let image: any` comment pattern in `index.ts`).
+- `esModuleInterop: true` is enabled; use default imports for CommonJS packages (e.g., `import path from 'node:path'`).
+- Use `node:` protocol for built-in Node modules: `import path from 'node:path'`, `import fs from 'node:fs'`.
+
+### Files to explore
+- @tsconfig.json
+- @src/index.ts
+
+---
+
+## Key Pattern: Express App Bootstrap
+
+The entire Express app lives in `src/index.ts`. There are no separate router files. Middleware is registered in this order: `urlencoded` → `json` → static routes → view engine config → route handlers → `app.listen`.
+
+```typescript
+import 'dotenv/config'
+import path from 'node:path';
+import express, { Express, Request, Response } from 'express'
+
+const app: Express = express();
+const port = process.env.PORT
+
+app.use(express.urlencoded({ extended: true }))
+app.use(express.json());
+// static middleware...
+// view engine config...
+// route handlers...
+
+app.listen(port, () => {
+    console.log(`App running on server port: http://localhost:${port}`)
+})
+```
+
+**Key rules:**
+- Import `Express`, `Request`, `Response` from `express` for type annotations.
+- Annotate the app variable: `const app: Express = express()`.
+- `import 'dotenv/config'` must be the first import in `src/index.ts` and in any model file that reads `process.env`.
+- Add new routes in `src/index.ts` unless the file grows beyond ~200 lines, at which point extract a router.
+
+### Files to explore
+- @src/index.ts
+
+---
+
+## Key Pattern: Route Handler Structure
+
+Route handlers use the `async (req: Request, res: Response)` signature. Query params are destructured from `req.query`; body params from `req.body`. Always guard against non-string query values with a `typeof` check before passing to model functions.
+
+```typescript
+app.get('/make-prompt', async (req: Request, res: Response) => {
+    const { prompt } = req.query || '';
+
+    // Guard: query params are string | string[] | ParsedQs
+    if (typeof prompt === 'string') {
+        // call model function
+    }
+})
+
+app.post('/make-image', async (req: Request, res: Response) => {
+    const { modelApi, promptRephrase, prompt } = req.body;
+    // body is already typed as any; destructure what you need
+})
+```
+
+**Key rules:**
+- Always `typeof param === 'string'` guard query parameters before using them.
+- Destructure named properties from `req.body` rather than accessing them repeatedly as `req.body.prop`.
+- Route handlers are `async` even when the route doesn't await anything, to allow future expansion.
+
+### Files to explore
+- @src/index.ts
+
+---
+
+## Key Pattern: SSE Streaming Routes
+
+Server-Sent Events are implemented manually (no library). The route sets response headers, defines a `sendEvent` helper, iterates the AI stream with `for await`, and sends chunks as `data: <json>\n\n`. An empty object `{}` signals stream completion to the client.
+
+```typescript
+app.get('/make-prompt', async (req: Request, res: Response) => {
+    res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+    });
+
+    const sendEvent = (data: object) => {
+        res.write(`data: ${JSON.stringify(data)}\n\n`);
+    }
+
+    // iterate stream
+    for await (const chunk of stream) {
+        sendEvent({ promptResponse: chunk.text() });
+    }
+    sendEvent({}); // signals done to the client
+})
+```
+
+**Key rules:**
+- Always set all three SSE headers: `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`.
+- Define `sendEvent` as a local `(data: object) => void` closure inside the route handler — do not make it a module-level function.
+- Send an empty object `{}` as the final event to signal stream completion.
+- Listen for `req.on('close', ...)` to log or clean up when the client disconnects.
+
+### Files to explore
+- @src/index.ts
+- @src/public/js/events.js
+
+---
+
+## Key Pattern: Static Asset Serving
+
+Assets from `node_modules` (PicoCSS, HTMx) are served via `express.static` with explicit `Content-Type` override in the `setHeaders` callback. Project static files are served from `src/public` via `__dirname`.
+
+```typescript
+// Project static files
+app.use(express.static(path.join(__dirname, 'public')))
+
+// node_modules assets — always set Content-Type explicitly
+app.use('/htmx', express.static(
+    path.join('node_modules', 'htmx.org', 'dist'),
+    {
+        setHeaders: (res, req, start) => {
+            res.set('Content-Type', 'application/javascript')
+        }
+    }
+))
+```
+
+**Key rules:**
+- Use `path.join(__dirname, 'public')` for project assets — never hardcode relative strings.
+- For `node_modules` assets, use `path.join('node_modules', ...)` (relative to project root, not `__dirname`).
+- Always set `Content-Type` explicitly when serving JS or CSS from `node_modules`.
+- Mount CSS frameworks at a short path alias (e.g., `/pico`, `/htmx`) that templates reference by convention.
+
+### Files to explore
+- @src/index.ts
+
+---
+
+## Key Pattern: Environment Variable Access
+
+Each model file that needs API credentials imports `dotenv/config` at the top and reads from `process.env` into a module-level `const`, providing a fallback empty string `|| ''` when the key is optional or when TypeScript requires a `string` type.
+
+```typescript
+import 'dotenv/config'
+
+const GEMINI_TOKEN = process.env.GEMINI_API_KEY || ''
+const genAI = new GoogleGenerativeAI(GEMINI_TOKEN)
+```
+
+**Key rules:**
+- Import `dotenv/config` as the first import in any file that reads `process.env`.
+- Assign `process.env.VAR` to a named `const` at module scope — do not inline `process.env.VAR` in function calls.
+- Use `|| ''` for string API tokens so TypeScript accepts the value as `string` (not `string | undefined`).
+- API tokens that a constructor accepts as optional (like `Replicate`) can pass `process.env.VAR` directly.
+- Never commit `.env`. Copy from `.env.example` when onboarding.
+
+### Files to explore
+- @src/models/gemini.ts
+- @src/models/openai.ts
+- @src/models/huggingface.ts
+- @src/models/replicate.ts
+- @.env.example
+
+---
+
+## Key Pattern: Model Dispatch via Switch
+
+Route handlers that support multiple AI backends use a `switch` on a `modelApi` string (values: `'hf'`, `'openai'`, `'replicate'`). Each `case` calls its model function and renders the same partial template with normalized props.
+
+```typescript
+switch (modelApi) {
+    case 'hf':
+        image = await hfImage(req.body.promptRephrase);
+        res.render(path.join('partials', 'generated-image'), {
+            generatedPrompt: image.altText,
+            imgUrl: image.imgUrl,
+            altText: image.altText,
+        })
+        break;
+    case 'openai':
+        image = await makeImage(req.body.promptRephrase);
+        res.render(path.join('partials', 'generated-image'), {
+            generatedPrompt: req.body.promptRephrase,
+            imgUrl: image,
+            altText: req.body.promptRephrase,
+        })
+        break;
+    // ...
+}
+```
+
+**Key rules:**
+- All cases render the same partial (`partials/generated-image`) with identical props: `generatedPrompt`, `imgUrl`, `altText`.
+- When adding a new model backend, add a new `case` here and a new file in `src/models/`.
+- The `modelApi` values (`'hf'`, `'openai'`, `'replicate'`) must match the `value` attributes on the radio inputs in `base.twig`.
+- Use `let image: any` with a comment when the return type varies across model functions — this is the established pattern.
+
+### Files to explore
+- @src/index.ts
+- @src/views/base.twig

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,60 @@
+# Copilot Instructions for ts-express-ai
+
+## Project Context
+
+A TypeScript + Express generative AI exploration app. Users submit a text prompt that is rephrased by Google Gemini (streamed via SSE) and then sent to one of three image-generation backends (OpenAI DALL-E, Hugging Face Stable Diffusion, or Replicate Flux). The UI is rendered server-side with Twig templates and wired with HTMx for partial updates and vanilla JS for SSE handling.
+
+Key areas:
+- `src/index.ts` — Express app bootstrap, all routes, middleware registration
+- `src/models/` — One file per AI provider (gemini, openai, huggingface, replicate)
+- `src/views/` — Twig templates: `base.twig` (full page), `partials/` (HTMx swap fragments)
+- `src/public/js/` — Vanilla JS SSE client (`events.js`)
+- `src/public/css/` — BEM-ish CSS with native nesting (`main.css`, `media-queries.css`)
+
+## Code Review Rules
+
+### TypeScript
+
+- Flag any use of `any` that is not accompanied by an explanatory inline comment. The established pattern is `let image: any; // return type varies across model functions`.
+- Flag `require()` — all imports must use ES module `import` syntax.
+- Flag Node built-in imports that do not use the `node:` protocol (e.g., `import fs from 'fs'` should be `import fs from 'node:fs'`).
+- Flag `process.env.VAR` used inline inside function bodies or constructor calls — all env vars must be read into a named module-level `const` first.
+- Flag any file that reads `process.env` but does not have `import 'dotenv/config'` as its first import.
+- Flag loosening or disabling of `strict`, `noImplicitAny`, or `strictNullChecks` in `tsconfig.json`.
+- Flag query parameters (`req.query.*`) passed to model functions without a `typeof param === 'string'` guard.
+
+For detailed rules, see `.github/instructions/typescript-express.instructions.md`.
+
+### AI Models
+
+- Flag any AI provider logic (client instantiation, API calls, prompt strings) added directly to `src/index.ts` — all provider code must live in `src/models/<provider>.ts`.
+- Flag default exports from model files — all exports must be named.
+- Flag client initialization (`new GoogleGenerativeAI(...)`, `new OpenAI({})`, etc.) inside function bodies — clients must be initialized at module scope.
+- Flag hardcoded model name strings inside function bodies — model identifiers must be module-level constants.
+- Flag Replicate model identifiers that do not include a full SHA version string (floating `latest` tags are not allowed).
+- Flag system prompt strings defined inside API call arguments — they must be module-level `const` values.
+- Flag Gemini being used for image generation — Gemini handles text and streaming only.
+
+For detailed rules, see `.github/instructions/ai-models.instructions.md`.
+
+### Frontend (Twig, HTMx, CSS, JS)
+
+- Flag Twig partial files that include `<html>`, `<head>`, or `<body>` tags — partials must output HTML fragments only.
+- Flag asset paths in Twig templates that do not use the established mount aliases (`pico/`, `htmx/`, `css/`, `js/`, `svg/`).
+- Flag `<script>` tags placed in `<head>` — `js/events.js` must be loaded at the bottom of `<body>`.
+- Flag HTMx buttons that are missing `hx-include="#prompt-form"` when they need to submit form data.
+- Flag HTMx indicator elements that are not using the `htmx-indicator` class for visibility toggling.
+- Flag hardcoded `512px` dimension values — use `var(--img-dim)` instead.
+- Flag CSS added to `main.css` that should be in `media-queries.css` (i.e., inside `@media` blocks).
+- Flag SSE client code that does not call `e.preventDefault()` on the form submit event before opening `EventSource`.
+- Flag SSE event handlers that do not parse `event.data` as JSON before reading properties.
+- Flag SSE chunk accumulation using `=` instead of `+=` on the result element's `innerHTML`.
+
+For detailed rules, see `.github/instructions/frontend.instructions.md`.
+
+### Security
+
+- Flag hardcoded API keys, tokens, or secrets in any file. All credentials must come from `process.env` and be listed in `.env.example` with placeholder values.
+- Flag `.env` files committed to the repository — `.env` must remain in `.gitignore`.
+- Flag `innerHTML` assignments that use unescaped user-supplied strings. The SSE `promptResult.innerHTML += data.promptResponse` pattern is acceptable only because the content originates from the AI model response, not raw user input.
+- Flag `process.env.VAR` used directly as an argument to a constructor or function call without being assigned to a named const first — this obscures which key is being used and makes rotation harder.

--- a/.github/instructions/ai-models.instructions.md
+++ b/.github/instructions/ai-models.instructions.md
@@ -1,0 +1,314 @@
+---
+applyTo: "src/models/**/*.ts"
+---
+
+# AI Models Standards
+
+## One File Per Provider
+
+### ENFORCE: All AI provider logic lives in `src/models/<provider>.ts`
+
+```
+src/models/
+  gemini.ts       → @google/generative-ai
+  openai.ts       → openai
+  huggingface.ts  → @huggingface/inference
+  replicate.ts    → replicate
+```
+
+### FLAG FOR REVIEW: AI provider code added to `src/index.ts`
+
+```typescript
+// WRONG — provider logic in the route file
+app.post('/make-image', async (req, res) => {
+    const openai = new OpenAI({});
+    const response = await openai.images.generate({ ... });
+})
+
+// CORRECT — provider logic in src/models/openai.ts, imported into index.ts
+import { makeImage } from './models/openai'
+app.post('/make-image', async (req, res) => {
+    const image = await makeImage(req.body.promptRephrase);
+})
+```
+
+### ENFORCE: Named exports only — no default exports from model files
+
+```typescript
+// CORRECT
+export { openai, makePrompt, makeImage }
+export { hfImage }
+export { replicateImage, replicateVideo }
+
+// WRONG
+export default makeImage
+```
+
+---
+
+## Client Initialization at Module Scope
+
+### ENFORCE: Clients initialized once at module scope, not inside functions
+
+```typescript
+// CORRECT
+const openai = new OpenAI({})
+const genAI = new GoogleGenerativeAI(GEMINI_TOKEN)
+const hf = new HfInference(HF_API_TOKEN)
+const replicate = new Replicate({ auth: process.env.REPLICATE_API_TOKEN })
+
+async function makeImage(prompt: string) {
+    // use the already-initialized client
+    return await openai.images.generate({ ... })
+}
+```
+
+### FLAG FOR REVIEW: Client created inside a function body
+
+```typescript
+// WRONG — creates a new client on every call
+async function makeImage(prompt: string) {
+    const openai = new OpenAI({});
+    return await openai.images.generate({ ... });
+}
+```
+
+---
+
+## Model Constants at Module Scope
+
+### ENFORCE: Model name strings as module-level constants, never hardcoded inside function calls
+
+```typescript
+// CORRECT — gemini.ts
+const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' })
+
+// CORRECT — huggingface.ts (snake_case for HuggingFace model variants)
+const model_stable = 'stabilityai/stable-diffusion-3-medium-diffusers'
+
+// CORRECT — replicate.ts (SCREAMING_SNAKE_CASE for version-pinned strings)
+const IMG_MODEL = 'adirik/flux-cinestill:216a43b9975de9768114644bbf8cd0cba54a923c6d0f65adceaccfc9383a938f'
+const VIDEO_MODEL = 'cjwbw/videocrafter:02edcff3e9d2d11dcc27e530773d988df25462b1ee93ed0257b6f246de4797c8'
+```
+
+### FLAG FOR REVIEW: Model string hardcoded inside a function or API call
+
+```typescript
+// WRONG
+async function makeImage(prompt: string) {
+    return await openai.images.generate({
+        model: 'dall-e-3',  // should be a module-level const
+        ...
+    })
+}
+```
+
+---
+
+## Replicate Version Pinning
+
+### ENFORCE: Replicate model identifiers must include a full SHA version string
+
+```typescript
+// CORRECT — SHA pinned
+const IMG_MODEL = 'adirik/flux-cinestill:216a43b9975de9768114644bbf8cd0cba54a923c6d0f65adceaccfc9383a938f'
+
+// WRONG — floating reference
+const IMG_MODEL = 'adirik/flux-cinestill:latest'
+const IMG_MODEL = 'adirik/flux-cinestill'
+```
+
+### ENFORCE: Arrow function syntax for Replicate wrapper functions
+
+```typescript
+// CORRECT
+const replicateImage = async (prompt: string) => {
+    return await replicate.run(IMG_MODEL, { input: { prompt, ... } })
+}
+
+// WRONG — function declaration syntax breaks the convention
+async function replicateImage(prompt: string) { ... }
+```
+
+---
+
+## System Prompts as Module Constants
+
+### ENFORCE: System prompts defined as module-level `const`, not embedded in API call arguments
+
+```typescript
+// CORRECT — gemini.ts
+const starterPrompt = `
+    You are an expert in prompt crafting.
+    Use the text input to craft a detailed prompt for image generation.
+    Keep the prompt length under 900 characters: `
+
+async function makeImagePrompt(userPrompt: string) {
+    const prompt = `${starterPrompt} ${userPrompt}`
+    const { stream } = await model.generateContentStream(prompt)
+    return stream;
+}
+```
+
+### FLAG FOR REVIEW: Prompt string inlined directly in the API call
+
+```typescript
+// WRONG — prompt instruction is buried inside the call
+const result = await model.generateContent(`
+    You are an expert in prompt crafting. ${userPrompt}
+`)
+```
+
+### ENFORCE: OpenAI system prompts use the `role: 'system'` message slot
+
+```typescript
+// CORRECT
+messages: [
+    { role: 'system', content: SYSTEM_PROMPT },
+    { role: 'user', content: userInput }
+]
+```
+
+---
+
+## Gemini Text and Streaming
+
+### ENFORCE: Use `generateContentStream` when the route needs to SSE-stream chunks
+
+```typescript
+// CORRECT — streaming variant returns the stream object
+async function makeImagePrompt(userPrompt: string) {
+    const { stream } = await model.generateContentStream(prompt)
+    return stream;
+}
+```
+
+### FLAG FOR REVIEW: Gemini used for image generation
+
+Gemini (`@google/generative-ai`) handles text generation and prompt rephrasing only. It cannot generate images. Route image generation to `openai.ts` (DALL-E 3), `huggingface.ts` (Stable Diffusion), or `replicate.ts` (Flux Cinestill).
+
+### ENFORCE: Check `chunk.candidates` before treating a chunk as final
+
+```typescript
+// CORRECT
+for await (const chunk of promptStream) {
+    if (chunk.candidates) {
+        if (chunk.candidates[0].finishReason === 'STOP') {
+            // final chunk handling
+        }
+        sendEvent({ promptResponse: chunk.text() });
+    }
+}
+```
+
+---
+
+## OpenAI Chat and Image
+
+### ENFORCE: `new OpenAI({})` with empty options object — SDK reads key from environment automatically
+
+```typescript
+// CORRECT
+const openai = new OpenAI({})
+
+// WRONG — passing key explicitly (unnecessary and risks accidental exposure)
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+```
+
+### ENFORCE: Streaming chat completions require both `stream: true` and `stream_options`
+
+```typescript
+// CORRECT
+const chatStream = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [...],
+    stream: true,
+    stream_options: { "include_usage": true },
+})
+```
+
+### ENFORCE: `makeImage` returns `response.data[0].url` — a string
+
+```typescript
+// CORRECT — returns the URL string
+async function makeImage(prompt: string) {
+    const response = await openai.images.generate({ model: 'dall-e-3', n: 1, prompt })
+    return response.data[0].url
+}
+```
+
+---
+
+## Hugging Face — Blob to Disk
+
+### ENFORCE: Explicit cast of `textToImage` response to `Blob`
+
+```typescript
+// CORRECT — SDK types the return loosely
+const blob = imgReq as Blob;
+```
+
+### ENFORCE: Use `blobToBuffer` helper for Blob → Buffer conversion; do not inline `arrayBuffer()`
+
+```typescript
+// CORRECT
+const buffer = await blobToBuffer(blob)
+
+// WRONG — inlining the conversion
+const buffer = Buffer.from(await imgReq.arrayBuffer())
+```
+
+### ENFORCE: Timestamp format for HuggingFace image filenames
+
+```typescript
+// CORRECT — consistent, filesystem-safe format
+const timestamp = new Date().toISOString()
+    .replace(/[:.]/g, '-').replace('T', '_').split('.')[0];
+await storeImage(blob, `hf-image-stable_${timestamp}.jpg`)
+```
+
+### ENFORCE: `imgUrl` paths must start with `/assets/` to resolve as static assets
+
+```typescript
+// CORRECT
+return { imgUrl: `/assets/images/hf-image-stable_${timestamp}.jpg`, altText: prompt }
+
+// WRONG — absolute filesystem path exposed as URL
+return { imgUrl: `/Users/edgarquintanilla/Sites/.../hf-image-stable.jpg` }
+```
+
+### ENFORCE: `storeImage` resolves the image root with `path.join(__dirname, '..', 'public', 'assets', 'images')`
+
+```typescript
+// CORRECT
+const imageRoot = path.join(__dirname, '..', 'public', 'assets', 'images')
+
+// WRONG — hardcoded absolute path
+const imageRoot = '/Users/edgarquintanilla/Sites/mergente/ts-express-ai/src/public/assets/images'
+```
+
+---
+
+## Code Review Checklist
+
+### ENFORCE:
+1. All AI provider logic (client init, API calls, prompts) lives in `src/models/<provider>.ts` — not in `src/index.ts`
+2. Named exports only — no `export default` from model files
+3. AI clients initialized at module scope, not inside function bodies
+4. Model name strings are module-level constants — never hardcoded in function calls
+5. Replicate model identifiers include a full SHA version string
+6. Arrow function syntax for all Replicate wrapper functions
+7. System prompts defined as module-level `const`, not embedded in API calls
+8. OpenAI initialized as `new OpenAI({})` with empty options
+9. Streaming OpenAI calls include both `stream: true` and `stream_options: { "include_usage": true }`
+10. `makeImage` returns `response.data[0].url` (string)
+11. HuggingFace `textToImage` response explicitly cast to `Blob`
+12. HuggingFace `imgUrl` return value starts with `/assets/` (not a filesystem path)
+13. `storeImage` uses `path.join(__dirname, '..', 'public', 'assets', 'images')` for the image root
+
+### FLAG FOR REVIEW:
+1. Gemini called for image generation — it handles text/streaming only
+2. `chunk.candidates` not checked before accessing `finishReason` in Gemini stream loops
+3. HuggingFace Blob → Buffer conversion inlined instead of using the `blobToBuffer` helper
+4. Replicate model identifier without a SHA pin (floating reference)
+5. New provider added without a corresponding file in `src/models/` and entry in `src/models/README.md`

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -1,0 +1,415 @@
+---
+applyTo: "src/views/**/*.twig,src/public/**/*.css,src/public/**/*.js"
+---
+
+# Frontend Standards
+
+## Twig Template Structure
+
+### ENFORCE: `base.twig` is the only full-page layout — partials output fragments only
+
+```twig
+{# CORRECT — base.twig contains the full page shell #}
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <link rel="stylesheet" href="pico/pico.classless.min.css">
+        <link rel="stylesheet" href="css/main.css">
+        <link rel="stylesheet" href="css/media-queries.css">
+        <script src="htmx/htmx.min.js"></script>
+        <title>{{ title }}</title>
+    </head>
+    <body>
+        ...
+        <script src="js/events.js"></script>
+    </body>
+</html>
+```
+
+### FLAG FOR REVIEW: Partial files that include `<html>`, `<head>`, or `<body>` tags
+
+```twig
+{# WRONG — partial should never include page structure #}
+<html>
+<body>
+<figure class="prompt__figure">...</figure>
+</body>
+</html>
+
+{# CORRECT — partial is a fragment only #}
+<figure class="prompt__figure">
+    <img id="img-response" src="{{ imgUrl }}" alt="{{ altText }}" class="gen-ai-image htmx-indicator" />
+    <img src="/svg/loaders/puff.svg" alt="loading" class="prompt__response-loader htmx-indicator" />
+</figure>
+```
+
+### ENFORCE: Asset paths must use the established mount aliases
+
+| Asset | Alias |
+|-------|-------|
+| PicoCSS | `pico/pico.classless.min.css` |
+| HTMx | `htmx/htmx.min.js` |
+| Project CSS | `css/main.css`, `css/media-queries.css` |
+| Project JS | `js/events.js` |
+| SVG assets | `/svg/loaders/puff.svg` |
+
+```twig
+{# WRONG — raw node_modules path #}
+<script src="/node_modules/htmx.org/dist/htmx.min.js"></script>
+
+{# CORRECT — uses the Express mount alias #}
+<script src="htmx/htmx.min.js"></script>
+```
+
+### ENFORCE: `<script src="js/events.js">` goes at the bottom of `<body>`, after all markup
+
+```twig
+{# CORRECT — script tag is the last element inside <body> #}
+    <script src="js/events.js"></script>
+</body>
+</html>
+
+{# WRONG — script in <head> or before the markup #}
+<head>
+    <script src="js/events.js"></script>
+</head>
+```
+
+### ENFORCE: Twig variables use `{{ variableName }}` syntax, comments use `{# ... #}`
+
+```twig
+{# CORRECT #}
+<title>{{ title }}</title>
+{# This is a Twig comment #}
+
+{# WRONG — HTML comment for template logic #}
+<!-- {{ title }} -->
+```
+
+---
+
+## Twig Partials as HTMx Swap Targets
+
+### ENFORCE: All partial renders pass `generatedPrompt`, `imgUrl`, and `altText`
+
+```typescript
+// CORRECT — all three props always included
+res.render(path.join('partials', 'generated-image'), {
+    generatedPrompt: req.body.promptRephrase,
+    imgUrl: image,
+    altText: req.body.promptRephrase,
+})
+
+// WRONG — missing props break forward compatibility
+res.render(path.join('partials', 'generated-image'), {
+    imgUrl: image,
+})
+```
+
+### ENFORCE: Use `path.join('partials', 'generated-image')` — no `.twig` extension
+
+```typescript
+// CORRECT — Twig engine appends the extension
+res.render(path.join('partials', 'generated-image'), { ... })
+
+// WRONG — extension causes a double-extension error
+res.render(path.join('partials', 'generated-image.twig'), { ... })
+```
+
+### ENFORCE: The partial's root element must be a single container
+
+```twig
+{# CORRECT — single <figure> root that replaces hx-target inner HTML #}
+<figure class="prompt__figure">
+    <img ... />
+    <img ... />
+</figure>
+
+{# WRONG — multiple root elements break hx-swap="innerHTML" #}
+<img ... />
+<img ... />
+```
+
+---
+
+## HTMx Attributes
+
+### ENFORCE: The "Generate Image" button requires all four HTMx attributes
+
+```html
+<!-- CORRECT -->
+<button
+    hx-post="/make-image"
+    hx-include="#prompt-form"
+    hx-target=".prompt__response-image"
+    hx-swap="innerHTML"
+    hx-indicator=".prompt__response"
+>Generate Image</button>
+```
+
+### FLAG FOR REVIEW: `hx-include` missing or pointing to the wrong selector
+
+```html
+<!-- WRONG — form fields will not be submitted -->
+<button hx-post="/make-image" hx-target=".prompt__response-image" hx-swap="innerHTML">
+
+<!-- CORRECT -->
+<button hx-post="/make-image" hx-include="#prompt-form" hx-target=".prompt__response-image" hx-swap="innerHTML">
+```
+
+### ENFORCE: `hx-swap="innerHTML"` — replaces content inside the target, not the target itself
+
+```html
+<!-- CORRECT — wrapper .prompt__response-image persists across swaps -->
+hx-swap="innerHTML"
+
+<!-- WRONG — replaces the wrapper element itself, breaking subsequent swaps -->
+hx-swap="outerHTML"
+```
+
+### ENFORCE: `htmx-indicator` class on elements that participate in loading state toggling
+
+HTMx automatically sets `opacity: 0` on elements with the `htmx-indicator` class and sets `opacity: 1` during a request. CSS overrides explicit visibility in non-request state.
+
+```html
+<!-- CORRECT — both the placeholder and the generated image carry htmx-indicator -->
+<img src="/svg/512x512.svg" class="prompt__response-placeholder htmx-indicator" />
+<img src="/svg/loaders/puff.svg" class="prompt__response-loader htmx-indicator" />
+```
+
+### FLAG FOR REVIEW: SSE handled via the HTMx SSE extension (`hx-ext="sse"`)
+
+The project uses vanilla JS `EventSource` for SSE streaming, not the HTMx SSE extension. The comment in `base.twig` documents why: `hx-ext="sse"` does not handle word-by-word updates correctly. Do not add `hx-ext="sse"` to the form or any element.
+
+---
+
+## SSE Client with EventSource
+
+### ENFORCE: `e.preventDefault()` called before opening `EventSource`
+
+```javascript
+// CORRECT
+form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    // ...open EventSource
+});
+
+// WRONG — page navigates away without preventDefault
+form.addEventListener('submit', (e) => {
+    const eventSource = new EventSource(url);
+});
+```
+
+### ENFORCE: Clear `promptResult.innerHTML = ''` before each new stream
+
+```javascript
+// CORRECT — clears previous response before new stream starts
+form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    promptResult.innerHTML = '';
+    // ...open EventSource
+});
+```
+
+### ENFORCE: Parse `event.data` as JSON — server sends `JSON.stringify({ promptResponse: '...' })`
+
+```javascript
+// CORRECT
+eventSource.onmessage = (event) => {
+    const data = JSON.parse(event.data);
+    if (data.promptResponse) { ... }
+};
+
+// WRONG — reading event.data as a raw string
+eventSource.onmessage = (event) => {
+    promptResult.innerHTML += event.data;
+};
+```
+
+### ENFORCE: Use `+=` to accumulate SSE chunks, not `=`
+
+```javascript
+// CORRECT — each chunk is an incremental piece
+promptResult.innerHTML += data.promptResponse;
+
+// WRONG — replaces the entire content on each chunk
+promptResult.innerHTML = data.promptResponse;
+```
+
+### ENFORCE: An event with no `promptResponse` key signals stream completion — re-enable the button
+
+```javascript
+// CORRECT
+if (data.promptResponse) {
+    form.querySelector('button').disabled = true;
+    promptResult.innerHTML += data.promptResponse;
+} else {
+    // empty object {} = stream complete
+    form.querySelector('button').disabled = false;
+}
+```
+
+### ENFORCE: `onerror` handler present on `EventSource`
+
+```javascript
+// CORRECT
+eventSource.onerror = (error) => {
+    console.error('EventSource error:', error);
+};
+```
+
+---
+
+## CSS Naming and Nesting
+
+### ENFORCE: BEM-inspired naming — `.block` and `.block__element`
+
+```css
+/* CORRECT */
+.prompt { ... }
+.prompt__submit-button { ... }
+.prompt__response-image { ... }
+.prompt__response-loader { ... }
+
+/* WRONG — modifier syntax not used in this codebase */
+.prompt--active { ... }
+.prompt__button--large { ... }
+```
+
+### ENFORCE: Native CSS nesting — no Sass or PostCSS
+
+```css
+/* CORRECT — native CSS nesting */
+.prompt {
+    max-width: var(--img-dim);
+
+    .prompt__submit-button {
+        display: flex;
+        width: var(--img-dim);
+    }
+}
+
+/* WRONG — Sass-style nesting with & */
+.prompt {
+    &__submit-button { ... }
+}
+```
+
+### ENFORCE: Responsive overrides go in `media-queries.css`, not inline in `main.css`
+
+```css
+/* WRONG — @media block inside main.css */
+.content {
+    display: flex;
+    @media (min-width: 1024px) {
+        flex-direction: row;
+    }
+}
+
+/* CORRECT — media-queries.css */
+@media (min-width: 1024px) {
+    .content {
+        flex-direction: row;
+    }
+}
+```
+
+---
+
+## CSS Custom Properties for Dimensions
+
+### ENFORCE: Never hardcode `512px` — use `var(--img-dim)`
+
+```css
+/* CORRECT */
+.prompt {
+    max-width: var(--img-dim);
+}
+.prompt__submit-button {
+    width: var(--img-dim);
+}
+
+/* WRONG */
+.prompt {
+    max-width: 512px;
+}
+```
+
+### ENFORCE: New shared values added to `:root` in `main.css`
+
+```css
+/* CORRECT */
+:root {
+    --img-dim: 512px;
+    --screen-tablet: 768px;
+    /* add new tokens here */
+}
+```
+
+### FLAG FOR REVIEW: PicoCSS variable overrides
+
+PicoCSS classless styles provide base typography and form styling. Avoid overriding PicoCSS CSS variables (prefixed `--pico-*`) unless the change is intentional and documented with a comment.
+
+---
+
+## HTMx Indicator Pattern
+
+### ENFORCE: Loading state toggling via `htmx-indicator` + CSS overrides — not inline JavaScript
+
+```css
+/* CORRECT — CSS manages visibility based on HTMx request state */
+.prompt__response-image .prompt__figure {
+    .prompt__response-placeholder.htmx-indicator,
+    .gen-ai-image.htmx-indicator {
+        opacity: 1;
+    }
+}
+
+.prompt__response.htmx-request {
+    .prompt__response-image .prompt__figure {
+        .htmx-indicator.prompt__response-placeholder,
+        .htmx-indicator.gen-ai-image {
+            opacity: 0;
+            display: none;
+        }
+    }
+}
+```
+
+### ENFORCE: Spinner SVG loaded from `/svg/loaders/puff.svg`
+
+```html
+<!-- CORRECT -->
+<img src="/svg/loaders/puff.svg" alt="loading" class="prompt__response-loader htmx-indicator" />
+
+<!-- WRONG — path not served by express.static -->
+<img src="./assets/loaders/puff.svg" />
+```
+
+---
+
+## Code Review Checklist
+
+### ENFORCE:
+1. Partial files contain only HTML fragments — no `<html>`, `<head>`, or `<body>` tags
+2. Asset paths in Twig templates use mount aliases (`pico/`, `htmx/`, `css/`, `js/`, `/svg/`)
+3. `<script src="js/events.js">` is the last element inside `<body>`
+4. All `res.render` calls for partials pass `generatedPrompt`, `imgUrl`, and `altText`
+5. `res.render` uses `path.join('partials', 'generated-image')` with no `.twig` extension
+6. HTMx "Generate Image" button has all four attributes: `hx-post`, `hx-include="#prompt-form"`, `hx-target`, `hx-swap="innerHTML"`, `hx-indicator`
+7. SSE `form.submit` handler calls `e.preventDefault()` before opening `EventSource`
+8. `promptResult.innerHTML = ''` clears content at the start of each form submission
+9. `event.data` parsed with `JSON.parse` before reading `promptResponse`
+10. SSE chunks accumulated with `+=`, not `=`
+11. `eventSource.onerror` handler is present
+12. CSS uses native nesting — no Sass/PostCSS syntax
+13. `var(--img-dim)` used instead of hardcoded `512px`
+14. Media query overrides in `media-queries.css`, not `main.css`
+15. Spinner SVGs served from `/svg/loaders/puff.svg`
+
+### FLAG FOR REVIEW:
+1. `hx-ext="sse"` added anywhere — SSE streaming is handled by vanilla JS `EventSource`, not HTMx extension
+2. `hx-swap="outerHTML"` on the image generation button — should be `innerHTML`
+3. Missing `htmx-indicator` class on elements that should participate in loading state
+4. PicoCSS variable overrides without an explanatory comment
+5. New breakpoints hardcoded in `media-queries.css` instead of added to `:root` as named custom properties

--- a/.github/instructions/typescript-express.instructions.md
+++ b/.github/instructions/typescript-express.instructions.md
@@ -1,0 +1,278 @@
+---
+applyTo: "src/**/*.ts"
+---
+
+# TypeScript & Express Standards
+
+## Strict TypeScript Config
+
+### ENFORCE: Never weaken the strict compiler flags
+
+```json
+// CORRECT — tsconfig.json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true
+  }
+}
+```
+
+### FLAG FOR REVIEW: Using `any` without an explanatory comment
+
+```typescript
+// WRONG
+let image: any;
+
+// CORRECT — explain why `any` is necessary
+let image: any; // return type varies across model functions (hfImage returns {imgUrl, altText}, makeImage returns string, replicateImage returns array)
+```
+
+### FLAG FOR REVIEW: Node built-in imports missing the `node:` protocol
+
+```typescript
+// WRONG
+import path from 'path';
+import fs from 'fs';
+
+// CORRECT
+import path from 'node:path';
+import fs from 'node:fs';
+```
+
+---
+
+## Express App Bootstrap
+
+### ENFORCE: Express type annotations on the app variable
+
+```typescript
+// CORRECT
+import express, { Express, Request, Response } from 'express'
+const app: Express = express();
+```
+
+### ENFORCE: Middleware registration order
+
+```typescript
+// CORRECT — this order must be preserved
+app.use(express.urlencoded({ extended: true }))
+app.use(express.json());
+// static middleware next...
+// view engine config next...
+// route handlers last...
+app.listen(port, () => { ... })
+```
+
+### FLAG FOR REVIEW: New router files being created
+
+```typescript
+// WRONG — adding a separate router file
+// src/routes/images.ts
+
+// CORRECT — add routes directly to src/index.ts unless the file exceeds ~200 lines
+// src/index.ts
+app.post('/make-image', async (req: Request, res: Response) => { ... })
+```
+
+---
+
+## Route Handler Structure
+
+### ENFORCE: `typeof` guard on query parameters before use
+
+```typescript
+// CORRECT
+app.get('/make-prompt', async (req: Request, res: Response) => {
+    const { prompt } = req.query || '';
+    if (typeof prompt === 'string') {
+        // safe to pass to model functions
+    }
+})
+```
+
+### FLAG FOR REVIEW: Query param passed to a function without a `typeof` check
+
+```typescript
+// WRONG
+const stream = await makeImagePrompt(req.query.prompt);
+
+// CORRECT
+if (typeof req.query.prompt === 'string') {
+    const stream = await makeImagePrompt(req.query.prompt);
+}
+```
+
+### ENFORCE: Destructure named properties from `req.body`
+
+```typescript
+// CORRECT
+const { modelApi, promptRephrase, prompt } = req.body;
+
+// WRONG — repeated access
+const result = await hfImage(req.body.promptRephrase);
+res.render('...', { altText: req.body.promptRephrase });
+```
+
+---
+
+## SSE Streaming Routes
+
+### ENFORCE: All three SSE headers must be present
+
+```typescript
+// CORRECT
+res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive',
+});
+```
+
+### ENFORCE: `sendEvent` defined as a local closure inside the route handler
+
+```typescript
+// CORRECT — defined inside the handler
+const sendEvent = (data: object) => {
+    res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+// WRONG — module-level function
+function sendEvent(res: Response, data: object) { ... }
+```
+
+### ENFORCE: Empty object `{}` as the final SSE event to signal stream completion
+
+```typescript
+// CORRECT
+for await (const chunk of stream) {
+    sendEvent({ promptResponse: chunk.text() });
+}
+sendEvent({}); // signals done to the client
+```
+
+### FLAG FOR REVIEW: Missing `req.on('close', ...)` cleanup listener
+
+```typescript
+// WRONG — no cleanup on disconnect
+app.get('/make-prompt', async (req, res) => {
+    // ...stream loop
+})
+
+// CORRECT
+app.get('/make-prompt', async (req, res) => {
+    // ...stream loop
+    req.on('close', () => {
+        console.log('Connection closed');
+    });
+})
+```
+
+---
+
+## Static Asset Serving
+
+### ENFORCE: Use `path.join(__dirname, 'public')` for project static files
+
+```typescript
+// CORRECT
+app.use(express.static(path.join(__dirname, 'public')))
+
+// WRONG — hardcoded relative string
+app.use(express.static('./src/public'))
+```
+
+### ENFORCE: Explicit `Content-Type` when serving assets from `node_modules`
+
+```typescript
+// CORRECT
+app.use('/htmx', express.static(
+    path.join('node_modules', 'htmx.org', 'dist'),
+    {
+        setHeaders: (res, req, start) => {
+            res.set('Content-Type', 'application/javascript')
+        }
+    }
+))
+
+// WRONG — no Content-Type override
+app.use('/htmx', express.static(path.join('node_modules', 'htmx.org', 'dist')))
+```
+
+---
+
+## Environment Variable Access
+
+### ENFORCE: `import 'dotenv/config'` as the first import in files that read `process.env`
+
+```typescript
+// CORRECT — first line in the file
+import 'dotenv/config'
+import path from 'node:path';
+// ...
+```
+
+### ENFORCE: Assign env vars to a named module-level `const` before use
+
+```typescript
+// CORRECT
+const GEMINI_TOKEN = process.env.GEMINI_API_KEY || ''
+const genAI = new GoogleGenerativeAI(GEMINI_TOKEN)
+
+// WRONG — inline in constructor call
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '')
+```
+
+### ENFORCE: `|| ''` fallback for string API tokens
+
+```typescript
+// CORRECT — TypeScript accepts string, not string | undefined
+const GEMINI_TOKEN = process.env.GEMINI_API_KEY || ''
+const HF_API_TOKEN = process.env.HF_API_TOKEN  // acceptable when the SDK accepts string | undefined
+```
+
+---
+
+## Model Dispatch via Switch
+
+### ENFORCE: All switch cases render the same partial with the same three props
+
+```typescript
+// CORRECT — every case passes generatedPrompt, imgUrl, altText
+res.render(path.join('partials', 'generated-image'), {
+    generatedPrompt: req.body.promptRephrase,
+    imgUrl: image,
+    altText: req.body.promptRephrase,
+})
+```
+
+### FLAG FOR REVIEW: A new `modelApi` case that does not match a radio input value in `base.twig`
+
+The `modelApi` values in the switch (`'hf'`, `'openai'`, `'replicate'`) must match the `value` attributes on the radio inputs in `src/views/base.twig`. Adding a new case without a matching radio input will make the backend unreachable from the UI.
+
+---
+
+## Code Review Checklist
+
+### ENFORCE:
+1. `strict`, `noImplicitAny`, `strictNullChecks` are never disabled in `tsconfig.json`
+2. Node built-in imports use the `node:` protocol
+3. `import express, { Express, Request, Response }` with `const app: Express` annotation
+4. Middleware registered in order: urlencoded → json → static → view engine → routes → listen
+5. All three SSE headers present: `text/event-stream`, `no-cache`, `keep-alive`
+6. `sendEvent` defined as a local closure inside the SSE route handler
+7. Final SSE event is always `sendEvent({})`
+8. `import 'dotenv/config'` is the first import in every file that reads `process.env`
+9. Env vars assigned to named module-level `const` before being passed to constructors
+10. `express.static` for `node_modules` assets includes an explicit `setHeaders` with `Content-Type`
+11. All model dispatch switch cases render `partials/generated-image` with `generatedPrompt`, `imgUrl`, `altText`
+
+### FLAG FOR REVIEW:
+1. Any use of `any` without an explanatory comment
+2. `require()` instead of `import`
+3. `process.env.VAR` inlined directly in a constructor or function argument
+4. Query parameters used without a `typeof param === 'string'` guard
+5. New router files before `src/index.ts` reaches ~200 lines
+6. Missing `req.on('close', ...)` listener in SSE route handlers
+7. New `modelApi` switch case whose string value has no matching radio input in `base.twig`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# ts-express-ai
+
+## Project Overview
+
+A TypeScript + Express generative AI exploration app. Users submit a text prompt that is rephrased by Google Gemini (streamed via SSE) and then sent to one of three image-generation backends (OpenAI DALL-E, Hugging Face Stable Diffusion, or Replicate Flux). The UI is rendered server-side with Twig templates and wired with HTMx for partial updates and vanilla JS for SSE handling.
+
+## Tech Stack
+
+- **Runtime:** Node.js 20.16.0 (`.nvmrc`)
+- **Language:** TypeScript 5.5 (`target: es2016`, `module: commonjs`, `strict: true`)
+- **Framework:** Express 4
+- **Templating:** Twig 1.17 (`src/views/`)
+- **Frontend:** HTMx 2 + PicoCSS 2 (classless) + vanilla JS (`src/public/`)
+- **AI SDKs:**
+  - `@google/generative-ai` — prompt rephrasing / text generation (Gemini 1.5 Flash)
+  - `openai` — chat completions (GPT-4o-mini) and image generation (DALL-E 3)
+  - `@huggingface/inference` — text-to-image (Stable Diffusion 3)
+  - `replicate` — image generation (Flux Cinestill) and video generation
+
+## Architecture
+
+```
+src/
+  index.ts          # Express app: middleware, routes, view engine config
+  models/           # One file per AI provider SDK
+    gemini.ts
+    openai.ts
+    huggingface.ts
+    replicate.ts
+  views/
+    base.twig       # Full-page layout
+    partials/
+      generated-image.twig   # HTMx swap target
+  public/
+    js/events.js    # SSE EventSource + form wiring
+    css/main.css    # BEM-ish scoped styles with CSS nesting
+    css/media-queries.css
+    assets/         # Static images
+```
+
+## Key Conventions
+
+- All AI provider logic lives in `src/models/` — one file per provider.
+- Routes are defined directly in `src/index.ts` (no separate router files currently).
+- Static assets from `node_modules` (PicoCSS, HTMx) are served via `express.static` with explicit `Content-Type` headers.
+- Environment variables are loaded via `dotenv/config` at the top of each model file that needs them.
+- `npm run dev` uses `nodemon` + `concurrently` to run `tsc --watch` and `ts-node` simultaneously.
+- Build output goes to `dist/` (`outDir`); source root is `src/` (`rootDir`).
+
+## Environment Variables
+
+See `.env.example`. Required keys:
+- `PORT`
+- `OPENAI_API_KEY`
+- `REPLICATE_API_TOKEN`
+- `HF_API_TOKEN`
+- `GEMINI_API_KEY`


### PR DESCRIPTION
## Summary
- Adds Claude Code project rules (`CLAUDE.md`, `.claude/rules/`) covering TypeScript/Express patterns, AI model integrations, and frontend conventions
- Adds GitHub Copilot instruction files (`.github/copilot-instructions.md`, `.github/instructions/`) scoped to the same domains
- Both sets of AI docs are derived from the existing codebase patterns and conventions

## Test plan
- [ ] Verify Claude Code picks up rules when working in scoped file paths
- [ ] Verify GitHub Copilot suggestions align with documented patterns